### PR TITLE
Rephrase client guidance in user guide

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -98,7 +98,7 @@ use pg_embedded_setup_unpriv::{TestCluster, error::BootstrapResult};
 fn exercise_cluster() -> BootstrapResult<()> {
     let cluster = TestCluster::new()?;
     let url = cluster.settings().url("app_db");
-    // Issue queries with your preferred client here.
+    // Issue queries using any preferred client here.
     drop(cluster); // PostgreSQL shuts down automatically.
     Ok(())
 }


### PR DESCRIPTION
## Summary
- reword the RAII test cluster example comment to avoid second-person phrasing

## Testing
- make fmt

------
https://chatgpt.com/codex/tasks/task_e_68fd90d28f848322a1a0a902679c1098

## Summary by Sourcery

Documentation:
- Update example comment to "Issue queries using any preferred client here" instead of second-person phrasing