### PR TITLE
Add root/pg_worker run info link

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ directories, starting the server, and cleaning up when the test ends.
 - **Observability**: Tracing spans for lifecycle events, with sensitive values
   automatically redacted.
 
+## Running as root / pg_worker
+
+If your tests run as `root` (common in containers/CI) and you hit privilege
+errors, ensure the `pg_worker` helper is configured via `PG_EMBEDDED_WORKER`.
+See the Users' Guide section on root-only test agents for the required setup
+and environment variables.[^root-worker]
+
+[^root-worker]: docs/users-guide.md#integrating-with-root-only-test-agents
+
 ## Learn more
 
 - [Users' Guide](docs/users-guide.md) — full documentation, async API,


### PR DESCRIPTION
Restructure the README to get developers to "Hello World" quickly and add a root/pg_worker run info link:

- Add a new "Running as root / pg_worker" subsection with guidance on configuring the `pg_worker` helper and a pointer to the Users' Guide section for root-only test agents (e.g. docs/users-guide.md#integrating-with-root-only-test-agents).
- Keep quick-start focus and point readers to the Users' Guide, Developers' Guide, and Roadmap for full details, rather than duplicating configuration information.
- Use horizontal rules between major sections for visual breathing room and follow British English spelling.

The previous README was comprehensive but could overwhelm readers before getting to a working example. The updated structure prioritises rapid adoption while guiding users to complete documentation as needed.

## Summary by Sourcery

Rewrite the README to emphasise quick PostgreSQL test setup with pg_embedded_setup_unpriv and guide readers to supporting documentation.

Documentation:
- Replace the detailed, configuration-heavy README with a concise, value-focused introduction and quick-start rstest example.
- Summarise features and testing patterns at a high level while linking out to the Users' Guide, Developers' Guide, and roadmap for full details.
- Document licensing and contribution guidelines more prominently, including links to ISC licence and AGENTS.md.
- Add a root/pg_worker run info link and cross-reference to the root-workers guidance in the Users' Guide.


📎 **Task**: https://www.devboxer.com/task/30154ba4-960f-4304-8dc4-2ab02a96f353