### PR TITLE
Update dependabot-automerge.yml

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -22,6 +22,6 @@ jobs:
       checks: read
       statuses: read
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@235d2d07b9a321364a742310873f6732d7228e72
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@98246364002def859ab550fe01ab3bca55dcfd61
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Bump the referenced commit SHA for the shared dependabot-automerge workflow used in GitHub Actions.