### PR TITLE
[codex] Add cargo binstall release metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+'on':
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing Git tag to publish, for example v0.5.0
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    name: Resolve release tag
+    runs-on: ubuntu-24.04
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - name: Resolve tag and version
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$INPUT_TAG"
+          else
+            tag="$REF_NAME"
+          fi
+
+          case "$tag" in
+            v*) ;;
+            *)
+              echo "Release tags must start with 'v': $tag" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+  create-release:
+    name: Create draft release
+    needs: prepare
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Create draft release when missing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          gh release create "$TAG" \
+            --draft \
+            --generate-notes \
+            --title "$TAG" \
+            --verify-tag
+
+  build-assets:
+    name: Build ${{ matrix.target }}
+    needs: [prepare, create-release]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@b61ad14766ae81b830abdaf066eb3d9b6c4f537b
+      - name: Build release archive
+        run: >-
+          make release-archive
+          TARGET=${{ matrix.target }}
+          VERSION=${{ needs.prepare.outputs.version }}
+      - name: Upload release archive
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: gh release upload "$TAG" dist/*.tgz --clobber
+
+  publish-release:
+    name: Publish release
+    needs: [prepare, build-assets]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Publish draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          gh release edit "$TAG" --draft=false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ documentation = "https://docs.rs/pg-embed-setup-unpriv/latest/pg_embedded_setup_
 homepage = "https://df12.studio/docs.html"
 repository = "https://github.com/leynos/pg-embedded-setup-unpriv"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }{ archive-suffix }"
+bin-dir = "{ name }-{ target }-v{ version }/{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
 [lib]
 name = "pg_embedded_setup_unpriv"
 path = "src/lib.rs"

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ release-archive: ## Package release binaries for cargo-binstall
 	$(CARGO) build $(BUILD_JOBS) --release --target "$(TARGET)" $(foreach bin,$(RELEASE_BINARIES),--bin $(bin))
 	rm -rf "$(RELEASE_ARCHIVE_DIR)" "$(RELEASE_ARCHIVE_FILE)"
 	mkdir -p "$(RELEASE_ARCHIVE_DIR)"
-	@for bin in $(RELEASE_BINARIES); do \
+	@set -e; for bin in $(RELEASE_BINARIES); do \
 		cp "target/$(TARGET)/release/$$bin" "$(RELEASE_ARCHIVE_DIR)/$$bin"; \
 	done
 	tar -C "$(DIST_DIR)" -czf "$(RELEASE_ARCHIVE_FILE)" "$(RELEASE_ARCHIVE_STEM)"

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,19 @@ BUILD_JOBS ?=
 DIST_DIR ?= dist
 RELEASE_BINARIES ?= pg_embedded_setup_unpriv pg_worker
 TARGET ?=
-MANIFEST_VERSION := $(shell sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)
+MANIFEST_VERSION := $(strip $(shell awk '\
+	/^\[package\]$$/ { in_package = 1; next } \
+	/^\[/ { if (in_package) exit; next } \
+	in_package && /^version[[:space:]]*=/ { \
+		if (match($$0, /"([^"]+)"/)) { \
+			print substr($$0, RSTART + 1, RLENGTH - 2); \
+			exit; \
+		} \
+	}' Cargo.toml))
 VERSION ?= $(MANIFEST_VERSION)
+ifeq ($(strip $(VERSION)),)
+$(error VERSION is empty; set [package].version in Cargo.toml or pass VERSION explicitly)
+endif
 RELEASE_ARCHIVE_STEM = pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)
 RELEASE_ARCHIVE_DIR = $(DIST_DIR)/$(RELEASE_ARCHIVE_STEM)
 RELEASE_ARCHIVE_FILE = $(RELEASE_ARCHIVE_DIR).tgz

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie typecheck
+.PHONY: help all clean test build release release-archive lint fmt check-fmt markdownlint nixie typecheck
 
 APP ?= pg_embedded_setup_unpriv
 CARGO ?= cargo
 BUILD_JOBS ?=
+DIST_DIR ?= dist
+RELEASE_BINARIES ?= pg_embedded_setup_unpriv pg_worker
+TARGET ?=
+VERSION ?= $(shell sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)
 CLIPPY_FLAGS ?= --all-targets --all-features -- -D warnings
 RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
 MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
 
 build: target/debug/$(APP) ## Build debug binary
-release: target/release/$(APP) ## Build release binary
+release: $(addprefix target/release/,$(RELEASE_BINARIES)) ## Build release binaries
 
 all: check-fmt lint test ## Perform all commit gate checks
 
@@ -20,8 +24,25 @@ test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) nextest run --all-targets --all-features $(BUILD_JOBS)
 	RUSTFLAGS="-D warnings" $(CARGO) nextest run --tests --workspace --no-default-features --features dev-worker $(BUILD_JOBS)
 
-target/%/$(APP): ## Build binary in debug or release mode
-	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(APP)
+target/%/pg_embedded_setup_unpriv target/%/pg_worker: ## Build binary in debug or release mode
+	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(@F)
+
+release-archive: ## Package release binaries for cargo-binstall
+	@test -n "$(TARGET)" || (echo "TARGET is required" >&2; exit 1)
+	$(CARGO) build $(BUILD_JOBS) --release --target "$(TARGET)" \
+		--bin pg_embedded_setup_unpriv \
+		--bin pg_worker
+	rm -rf "$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)" \
+		"$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION).tgz"
+	mkdir -p "$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)"
+	cp "target/$(TARGET)/release/pg_embedded_setup_unpriv" \
+		"$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)/pg_embedded_setup_unpriv"
+	cp "target/$(TARGET)/release/pg_worker" \
+		"$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)/pg_worker"
+	tar -C "$(DIST_DIR)" \
+		-czf "$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION).tgz" \
+		"pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)"
+	rm -rf "$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)"
 
 lint: ## Run Clippy with warnings denied
 	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --workspace --no-deps $(BUILD_JOBS)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ BUILD_JOBS ?=
 DIST_DIR ?= dist
 RELEASE_BINARIES ?= pg_embedded_setup_unpriv pg_worker
 TARGET ?=
-VERSION ?= $(shell sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)
+MANIFEST_VERSION := $(shell sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)
+VERSION ?= $(MANIFEST_VERSION)
+RELEASE_ARCHIVE_STEM = pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)
+RELEASE_ARCHIVE_DIR = $(DIST_DIR)/$(RELEASE_ARCHIVE_STEM)
+RELEASE_ARCHIVE_FILE = $(RELEASE_ARCHIVE_DIR).tgz
 CLIPPY_FLAGS ?= --all-targets --all-features -- -D warnings
 RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
 MDLINT ?= markdownlint-cli2
@@ -32,23 +36,16 @@ target/%/pg_worker: ## Build binary in debug or release mode
 
 release-archive: ## Package release binaries for cargo-binstall
 	@test -n "$(TARGET)" || (echo "TARGET is required" >&2; exit 1)
-	@manifest_version="$$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"; \
-		test "$$manifest_version" = "$(VERSION)" || \
-		(echo "VERSION ($(VERSION)) must match Cargo.toml package version ($$manifest_version)" >&2; exit 1)
-	$(CARGO) build $(BUILD_JOBS) --release --target "$(TARGET)" \
-		--bin pg_embedded_setup_unpriv \
-		--bin pg_worker
-	rm -rf "$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)" \
-		"$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION).tgz"
-	mkdir -p "$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)"
-	cp "target/$(TARGET)/release/pg_embedded_setup_unpriv" \
-		"$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)/pg_embedded_setup_unpriv"
-	cp "target/$(TARGET)/release/pg_worker" \
-		"$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)/pg_worker"
-	tar -C "$(DIST_DIR)" \
-		-czf "$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION).tgz" \
-		"pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)"
-	rm -rf "$(DIST_DIR)/pg-embed-setup-unpriv-$(TARGET)-v$(VERSION)"
+	@test "$(MANIFEST_VERSION)" = "$(VERSION)" || \
+		(echo "VERSION ($(VERSION)) must match Cargo.toml package version ($(MANIFEST_VERSION))" >&2; exit 1)
+	$(CARGO) build $(BUILD_JOBS) --release --target "$(TARGET)" $(foreach bin,$(RELEASE_BINARIES),--bin $(bin))
+	rm -rf "$(RELEASE_ARCHIVE_DIR)" "$(RELEASE_ARCHIVE_FILE)"
+	mkdir -p "$(RELEASE_ARCHIVE_DIR)"
+	@for bin in $(RELEASE_BINARIES); do \
+		cp "target/$(TARGET)/release/$$bin" "$(RELEASE_ARCHIVE_DIR)/$$bin"; \
+	done
+	tar -C "$(DIST_DIR)" -czf "$(RELEASE_ARCHIVE_FILE)" "$(RELEASE_ARCHIVE_STEM)"
+	rm -rf "$(RELEASE_ARCHIVE_DIR)"
 
 lint: ## Run Clippy with warnings denied
 	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --workspace --no-deps $(BUILD_JOBS)

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,11 @@ test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) nextest run --all-targets --all-features $(BUILD_JOBS)
 	RUSTFLAGS="-D warnings" $(CARGO) nextest run --tests --workspace --no-default-features --features dev-worker $(BUILD_JOBS)
 
-target/%/pg_embedded_setup_unpriv target/%/pg_worker: ## Build binary in debug or release mode
-	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin $(@F)
+target/%/pg_embedded_setup_unpriv: ## Build binary in debug or release mode
+	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin pg_embedded_setup_unpriv
+
+target/%/pg_worker: ## Build binary in debug or release mode
+	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin pg_worker
 
 release-archive: ## Package release binaries for cargo-binstall
 	@test -n "$(TARGET)" || (echo "TARGET is required" >&2; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,11 @@ RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
 MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
 
-build: target/debug/$(APP) ## Build debug binary
-release: $(addprefix target/release/,$(RELEASE_BINARIES)) ## Build release binaries
+build: ## Build debug binary
+	$(CARGO) build $(BUILD_JOBS) --bin "$(APP)"
+
+release: ## Build release binaries
+	$(CARGO) build $(BUILD_JOBS) --release $(foreach bin,$(RELEASE_BINARIES),--bin $(bin))
 
 all: check-fmt lint test ## Perform all commit gate checks
 
@@ -38,12 +41,6 @@ clean: ## Remove build artifacts
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) nextest run --all-targets --all-features $(BUILD_JOBS)
 	RUSTFLAGS="-D warnings" $(CARGO) nextest run --tests --workspace --no-default-features --features dev-worker $(BUILD_JOBS)
-
-target/%/pg_embedded_setup_unpriv: ## Build binary in debug or release mode
-	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin pg_embedded_setup_unpriv
-
-target/%/pg_worker: ## Build binary in debug or release mode
-	$(CARGO) build $(BUILD_JOBS) $(if $(findstring release,$(@)),--release) --bin pg_worker
 
 release-archive: ## Package release binaries for cargo-binstall
 	@test -n "$(TARGET)" || (echo "TARGET is required" >&2; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ all: check-fmt lint test ## Perform all commit gate checks
 
 clean: ## Remove build artifacts
 	$(CARGO) clean
-	rm -rf "$(RELEASE_ARCHIVE_DIR)" "$(RELEASE_ARCHIVE_FILE)" "$(DIST_DIR)"
+	rm -rf "$(DIST_DIR)"
 
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) nextest run --all-targets --all-features $(BUILD_JOBS)

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ target/%/pg_embedded_setup_unpriv target/%/pg_worker: ## Build binary in debug o
 
 release-archive: ## Package release binaries for cargo-binstall
 	@test -n "$(TARGET)" || (echo "TARGET is required" >&2; exit 1)
+	@manifest_version="$$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"; \
+		test "$$manifest_version" = "$(VERSION)" || \
+		(echo "VERSION ($(VERSION)) must match Cargo.toml package version ($$manifest_version)" >&2; exit 1)
 	$(CARGO) build $(BUILD_JOBS) --release --target "$(TARGET)" \
 		--bin pg_embedded_setup_unpriv \
 		--bin pg_worker

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ all: check-fmt lint test ## Perform all commit gate checks
 
 clean: ## Remove build artifacts
 	$(CARGO) clean
+	rm -rf "$(RELEASE_ARCHIVE_DIR)" "$(RELEASE_ARCHIVE_FILE)" "$(DIST_DIR)"
 
 test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) nextest run --all-targets --all-features $(BUILD_JOBS)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ pg-embed-setup-unpriv = "0.5"
 rstest = "0.26"
 ```
 
+For the published CLI binaries on Linux `x86_64` and `aarch64`, install the
+release archive with:
+
+```sh
+cargo binstall pg-embed-setup-unpriv
+```
+
 ### Basic usage
 
 ```rust

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -23,6 +23,16 @@ also runs a Linux matrix for unprivileged and root execution. The root variant
 invokes the test suite under `sudo` so root-only privilege paths execute, while
 the unprivileged variant continues to collect coverage.
 
+## Release process
+
+Tagging a release with `v*` triggers `.github/workflows/release.yml`. The
+workflow creates a draft GitHub release, builds native Linux archives on
+`ubuntu-24.04` and `ubuntu-24.04-arm`, and uploads
+`pg-embed-setup-unpriv-{target}-v{version}.tgz` assets containing both
+`pg_embedded_setup_unpriv` and `pg_worker`. `Cargo.toml` exposes matching
+`[package.metadata.binstall]` entries so `cargo binstall pg-embed-setup-unpriv`
+can install those published assets on Linux `x86_64` and `aarch64`.
+
 ## Loom concurrency tests
 
 Loom-based checks for `ScopedEnv` are opt-in and only compile when the

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -52,6 +52,13 @@ Troubleshooting guidance:
 
 ## Quick start
 
+On Linux `x86_64` and `aarch64`, tagged releases publish both CLI binaries in a
+`cargo binstall` archive. Install them with:
+
+```bash
+cargo binstall pg-embed-setup-unpriv
+```
+
 1. Choose directories for the staged PostgreSQL distribution and the cluster’s
    data files. They must be writable by whichever user will run the helper; the
    tool reapplies ownership and permissions on every invocation.


### PR DESCRIPTION
## What changed
- add explicit `[package.metadata.binstall]` entries so `cargo binstall` can resolve published Linux release archives
- add a `make release-archive` target that packages `pg_embedded_setup_unpriv` and `pg_worker` into the archive layout expected by the metadata
- add a tag-driven GitHub Actions release workflow that builds and uploads native Linux `x86_64` and `aarch64` assets, then publishes the release
- document the `cargo binstall pg-embed-setup-unpriv` install path in the README and guides

## Why
The crate did not publish `cargo binstall` metadata or a release build path that produced matching assets, so `cargo binstall` could not install the shipped binaries from GitHub releases.

## Impact
Linux consumers on `x86_64` and `aarch64` can install the published CLI binaries directly with `cargo binstall`, and tagged releases now build the matching artifacts automatically.

## Validation
- `make release-archive TARGET=x86_64-unknown-linux-gnu VERSION=0.5.0`
- `make fmt`
- `make check-fmt`
- `make markdownlint`
- `make nixie`
- `make lint`
- `make test`

## Notes
- the local packaging path was validated on the host `x86_64-unknown-linux-gnu` target
- the new GitHub Actions workflow defines the native `aarch64` build on `ubuntu-24.04-arm`, but that runner path was not executed locally

## Summary by Sourcery

Add release packaging and automation to support installing the CLI binaries via cargo-binstall from GitHub releases.

New Features:
- Introduce a make release-archive target that builds and packages the release binaries into a distributable archive.
- Expose cargo-binstall metadata in Cargo.toml so published release archives can be resolved and installed as a package.
- Add a tag-driven GitHub Actions workflow that builds and uploads Linux release archives for x86_64 and aarch64 and publishes the release.

Build:
- Update Makefile release targets to build both CLI binaries and generate archives matching the cargo-binstall metadata.

CI:
- Add a release GitHub Actions workflow that prepares draft releases, builds platform-specific archives, uploads them, and publishes the release.

Documentation:
- Document the cargo-binstall installation path for the published CLI binaries in the README and user and developer guides.