### PR TITLE
Tighten users guide examples

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -362,6 +362,8 @@ assert!(std::ptr::eq(cluster, cluster2));
 | `test_cluster`        | Tests that modify cluster-level settings or state |
 | `shared_test_cluster` | Tests that only need database-level isolation     |
 
+_Table 1: Fixture selection for `pg-embed-setup-unpriv` test clusters._
+
 The shared cluster is particularly effective when combined with template
 databases (see "Database lifecycle management" below) to reduce per-test
 overhead from seconds to milliseconds.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -534,7 +534,11 @@ template invalidation explicit without hashing the migration directory.
 
 ### Performance comparison
 
-The following table compares test isolation approaches:
+The following table reports approximate benchmark results from one development
+test environment. Treat the timings as environment-dependent guidance rather
+than guaranteed performance figures.
+
+_Table 2: Performance comparison for test isolation approaches._
 
 | Approach                       | Bootstrap | Per-test overhead | Isolation |
 | ------------------------------ | --------- | ----------------- | --------- |

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -362,7 +362,7 @@ assert!(std::ptr::eq(cluster, cluster2));
 | `test_cluster`        | Tests that modify cluster-level settings or state |
 | `shared_test_cluster` | Tests that only need database-level isolation     |
 
-_Table 1: Fixture selection for `pg-embed-setup-unpriv` test clusters._
+_Table 2: Fixture selection for `pg-embed-setup-unpriv` test clusters._
 
 The shared cluster is particularly effective when combined with template
 databases (see "Database lifecycle management" below) to reduce per-test
@@ -538,7 +538,7 @@ The following table reports approximate benchmark results from one development
 test environment. Treat the timings as environment-dependent guidance rather
 than guaranteed performance figures.
 
-_Table 2: Performance comparison for test isolation approaches._
+_Table 3: Performance comparison for test isolation approaches._
 
 | Approach                       | Bootstrap | Per-test overhead | Isolation |
 | ------------------------------ | --------- | ----------------- | --------- |

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -105,8 +105,8 @@ cargo binstall pg-embed-setup-unpriv
    Ownership fix-ups occur on every call, so running the tool twice remains
    idempotent.
 
-4. Pass the resulting paths and credentials to your tests. If you use
-   `postgresql_embedded` directly after the setup step, it can reuse the staged
+4. Pass the resulting paths and credentials to the test suite. Direct
+   `postgresql_embedded` usage after the setup step can reuse the staged
    binaries and data directory without needing `root`.
 
 ## Bootstrap for test suites
@@ -145,9 +145,9 @@ rather than when PostgreSQL launches.
 
 `bootstrap_for_tests()` also inserts a small set of PostgreSQL server
 configuration entries into `bootstrap.settings.configuration` to minimize
-background and parallel worker processes for ephemeral test clusters. Override
-these values by mutating the configuration map before starting the cluster if
-your tests need different behaviour.
+background and parallel worker processes for ephemeral test clusters. Suites
+that need different behaviour can override these values by mutating the
+configuration map before starting the cluster.
 
 ## Resource Acquisition Is Initialization (RAII) test clusters
 
@@ -204,7 +204,7 @@ Enable the feature in your `Cargo.toml`:
 
 ```toml
 [dev-dependencies]
-pg-embed-setup-unpriv = { version = "0.2", features = ["async-api"] }
+pg-embed-setup-unpriv = { version = "0.5.1", features = ["async-api"] }
 ```
 
 Then use `start_async()` and `stop_async()` in your async tests:
@@ -315,18 +315,28 @@ eliminating per-test bootstrap overhead.
 ```rust,no_run
 use pg_embedded_setup_unpriv::{test_support::shared_test_cluster, TestCluster};
 use rstest::rstest;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DB_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_database_name() -> String {
+    let id = DB_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("shared_cluster_test_{}_{id}", std::process::id())
+}
 
 #[rstest]
 fn uses_shared_cluster(shared_test_cluster: &'static TestCluster) {
-    // Create a per-test database for isolation
-    shared_test_cluster.create_database("my_test_db").unwrap();
+    let db_name = unique_database_name();
 
-    // Run tests against the database
-    let url = shared_test_cluster.connection().database_url("my_test_db");
-    assert!(url.contains("my_test_db"));
+    // Create a per-test database for isolation.
+    shared_test_cluster.create_database(&db_name).unwrap();
 
-    // Clean up (optional - the database is dropped when the cluster shuts down)
-    shared_test_cluster.drop_database("my_test_db").unwrap();
+    // Run tests against the database.
+    let url = shared_test_cluster.connection().database_url(&db_name);
+    assert!(url.contains(&db_name));
+
+    // Clean up the per-test database.
+    shared_test_cluster.drop_database(&db_name).unwrap();
 }
 ```
 


### PR DESCRIPTION
## Summary

This branch tightens the `pg-embed-setup-unpriv` users guide examples so they match the current 0.5.1 release and avoid copy-paste hazards in parallel shared-cluster tests.

It updates [docs/users-guide.md](https://github.com/leynos/pg-embed-setup-unpriv/blob/7258c9bd510b7ac1823b3eef167fca10220a325b/docs/users-guide.md) to:

- use `pg-embed-setup-unpriv` 0.5.1 in the `async-api` dependency snippet;
- generate a unique database name in the `shared_test_cluster` example while preserving explicit `create_database` and `drop_database` usage;
- reword the bootstrap setup text in impersonal form for the non-README documentation style.

## Review walkthrough

- Start with [docs/users-guide.md](https://github.com/leynos/pg-embed-setup-unpriv/blob/7258c9bd510b7ac1823b3eef167fca10220a325b/docs/users-guide.md#L92) for the bootstrap wording update.
- Then review [the async dependency snippet](https://github.com/leynos/pg-embed-setup-unpriv/blob/7258c9bd510b7ac1823b3eef167fca10220a325b/docs/users-guide.md#L187) for the 0.5.1 version alignment.
- Finish with [the shared cluster example](https://github.com/leynos/pg-embed-setup-unpriv/blob/7258c9bd510b7ac1823b3eef167fca10220a325b/docs/users-guide.md#L299) for the generated database name and scoped cleanup.

## Validation

- `make fmt`: passed; unrelated formatter normalisations were restored so this branch keeps only `docs/users-guide.md` changed.
- `make check-fmt`: passed.
- `make markdownlint`: passed.
- `make nixie`: passed.
- `git diff --check`: passed.
- `make lint`: passed.
- `make test`: passed; first nextest pass reported 270 passed and 4 skipped, second pass reported 156 passed and 0 skipped.



## References

- [Lody session](https://lody.ai/leynos/sessions/8580cd46-1bb5-411d-aea0-e20b083bd8fb)
