### PR TITLE
Wire main-branch coverage upload to CodeScene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,15 @@ jobs:
       BUILD_PROFILE: debug
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       WHITAKER_INSTALLER_VERSION: '0.2.5'
+      # Embedded-Postgres tests run slower under cold coverage
+      # instrumentation than the default 600s cargo wall-clock cap.
+      RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@d0fd973d07088c2120329a93035a5ba91e077014
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Format
         if: ${{ matrix.privilege == 'unprivileged' }}
         run: make check-fmt
@@ -80,12 +83,13 @@ jobs:
           cargo nextest run --all-targets --all-features
       - name: Test and Measure Coverage (unprivileged)
         if: ${{ matrix.privilege == 'unprivileged' }}
-        uses: leynos/shared-actions/.github/actions/generate-coverage@d0fd973d07088c2120329a93035a5ba91e077014
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           output-path: lcov.info
           format: lcov
           features: dev-worker
           with-default-features: "false"
+          with-ratchet: 'true'
       - name: Loom Concurrency Tests (non-blocking)
         if: ${{ always() && matrix.privilege == 'unprivileged' }}
         run: make test-loom
@@ -110,15 +114,18 @@ jobs:
               "$@"
           }
           run_as_root make test
-      - name: Upload coverage data to CodeScene
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: ${{ env.CS_ACCESS_TOKEN && matrix.privilege == 'unprivileged' }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@d28e04c9ea359650a85d697d1ab3d0be0b5674e7
-        with:
-          format: lcov
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+      # A `mode: check` step is deliberately not wired in here: CodeScene
+      # only accepts `cs-coverage upload` for analysed branches (main),
+      # so the previous unguarded default-mode step would be rejected on
+      # every pull request once CS_ACCESS_TOKEN is set. Main-branch
+      # coverage is uploaded from coverage-main.yml instead. The
+      # changed-line `check` gate needs a per-project CodeScene gates
+      # configuration that has not been enabled for this project yet
+      # (see the estate rollout notes for the byte-identical failure on
+      # ddlint and chutoro). Add the check step in a fast-follow PR once
+      # coverage-main.yml has uploaded to main at least once and the
+      # gate is confirmed to resolve, or once CodeScene confirms the
+      # project's coverage gate is enabled.
 
   cross-platform-tests:
     name: Test (${{ matrix.target }})
@@ -145,7 +152,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@d0fd973d07088c2120329a93035a5ba91e077014
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Restore PostgreSQL binary cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
@@ -205,7 +212,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@d0fd973d07088c2120329a93035a5ba91e077014
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Setup uv
         uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244
         with:

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,50 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests do not
+# run a changed-line gate yet (see the comment in ci.yml on the
+# `mode: check` step deferral). This workflow also advances the
+# coverage ratchet baseline: caches saved on main are readable by every
+# pull-request run, so the baseline written here is the one the PR
+# ratchet check compares against.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Embedded-Postgres tests run slower under cold coverage
+      # instrumentation than the default 600s cargo wall-clock cap.
+      RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: lcov.info
+          format: lcov
+          features: dev-worker
+          with-default-features: "false"
+          with-ratchet: 'true'
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@d0fd973d07088c2120329a93035a5ba91e077014
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
           persist-credentials: false
           ref: ${{ needs.prepare.outputs.tag }}
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@d0fd973d07088c2120329a93035a5ba91e077014
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Setup uv
         uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244
         with:
@@ -142,7 +142,7 @@ jobs:
           persist-credentials: false
           ref: ${{ needs.prepare.outputs.tag }}
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@d0fd973d07088c2120329a93035a5ba91e077014
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Download draft release assets
         shell: bash
         env:
@@ -246,7 +246,7 @@ jobs:
           persist-credentials: false
           ref: ${{ needs.prepare.outputs.tag }}
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@d0fd973d07088c2120329a93035a5ba91e077014
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Dry-run published release asset URLs
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- Bump every `leynos/shared-actions/...` pin in this repository to
  `927edd45ae77be4251a8a18ca9eb5613a2e32cbd` (the commit that adds the
  `mode: check` coverage gate to `upload-codescene-coverage`), across
  [`ci.yml`](https://github.com/leynos/pg-embed-setup-unpriv/blob/codescene-coverage-gate/.github/workflows/ci.yml),
  [`release.yml`](https://github.com/leynos/pg-embed-setup-unpriv/blob/codescene-coverage-gate/.github/workflows/release.yml)
  and
  [`dependabot-automerge.yml`](https://github.com/leynos/pg-embed-setup-unpriv/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml).
- Enable the coverage ratchet (`with-ratchet: 'true'`) on the single
  existing `generate-coverage` invocation in the unprivileged CI leg.
- Add
  [`coverage-main.yml`](https://github.com/leynos/pg-embed-setup-unpriv/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml),
  which uploads coverage to CodeScene (project
  [81799](https://codescene.io/projects/81799)) on every push to
  `main` and writes the authoritative ratchet baseline that PR runs
  compare against.
- Remove the pre-existing, unguarded "Upload coverage data to
  CodeScene" step from the PR job in `ci.yml`. That step used the
  action's default `mode: upload`, which CodeScene only accepts for
  branches it analyses (`main`); once `CS_ACCESS_TOKEN` is set, it
  would have started failing on every pull request. Main-branch
  uploads now live exclusively in `coverage-main.yml`.
- Raise `RUN_RUST_CARGO_WAIT_TIMEOUT` to `1800` (from the shared
  action's 600s default) in both the CI job and `coverage-main.yml`,
  since embedded-Postgres tests can run long under cold coverage
  instrumentation.

## Review walkthrough

The CodeScene "Code Coverage" PR check is **not** wired up in this PR.
CodeScene rejects the changed-line `cs-coverage check` gate with "Lacks
the gates configuration" for every project observed so far except mxd
(see the estate rollout notes) — enabling that gate is a CodeScene-side
per-project setting, not something this CI change can control. A
comment in `ci.yml` documents the deferral and the follow-up condition
(either the gate resolves once main has uploaded coverage, or CodeScene
confirms it manually).

Because the CodeScene coverage check is not a required status check on
this repository's ruleset (only `selftest`, `Linux Build and Test
(unprivileged)` and `Linux Build and Test (root)` are required), this
change carries no risk of blocking the merge queue even if CodeScene's
check remains absent or pending after merge.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open(f))"` over every
  workflow file in `.github/workflows/` — all parse cleanly.
- No workflow-contract tests reference these files or the
  shared-actions pin, so none needed updating.
- Full local build/test suites were intentionally not run (shared
  machine; per rollout policy, cheap validation only).

Once this merges, the `CS_ACCESS_TOKEN` secret will be set in both the
Actions and Dependabot secret stores, immediately before merge, to
avoid rejecting in-flight PR runs.

## Summary by Sourcery

Wire main-branch coverage generation and upload to CodeScene while tightening PR coverage handling and updating shared CI actions.

New Features:
- Add a dedicated coverage-main workflow that generates coverage on main pushes and uploads it to CodeScene with a ratcheted baseline.

Enhancements:
- Enable coverage ratchet mode for the existing unprivileged CI coverage generation step.
- Increase the Rust cargo wait timeout in CI and coverage workflows to accommodate longer embedded-Postgres tests.
- Update all references to leynos/shared-actions pins in CI, release, and Dependabot automerge workflows to a newer shared-actions commit.

CI:
- Remove the previous unguarded CodeScene coverage upload step from the PR CI workflow and document the planned follow-up for enabling the CodeScene check gate.