### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       BUILD_PROFILE: debug
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MERMAN_CLI_VERSION: '0.7.0'
-      WHITAKER_INSTALLER_VERSION: '0.2.5'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
       # Embedded-Postgres tests run slower under cold coverage
       # instrumentation than the default 600s cargo wall-clock cap.
       RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'


### PR DESCRIPTION
## Summary

This pull request bumps the pinned `whitaker-installer` version in [`.github/workflows/ci.yml`](https://github.com/leynos/pg-embed-setup-unpriv/blob/bump-whitaker-installer-0.2.6/.github/workflows/ci.yml) from `0.2.5` to `0.2.6`.

The whitaker Dylint suite's rolling release now pins toolchain `nightly-2026-05-28`, which requires `cargo-dylint` 6.0.1. Installer 0.2.5 provisions `cargo-dylint` 4.1.0, whose driver cannot compile on that nightly, so the repository's CI lint step is currently red. `whitaker-installer` 0.2.6, published today, provisions `cargo-dylint` 6.0.1 and resolves the incompatibility.

Note that the v0.2.6 GitHub release currently has no prebuilt assets, so `cargo binstall` will fall back to compiling from crates.io during CI. This is expected and acceptable.

## Test plan

- [ ] CI lint job passes with `whitaker-installer` 0.2.6 and toolchain `nightly-2026-05-28`.
