### PR TITLE
Make the VERSION guard representable to static Makefile parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,7 +1000,7 @@ dependencies = [
  "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "self_cell",
  "smallvec",
  "unic-langid",
@@ -1929,6 +1935,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "makefile-lossless"
+version = "0.3.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a892a73d2d24783ef4355b310e9d04e5a1c91aabca3c417d60ac524d64e4217a"
+dependencies = [
+ "log",
+ "rowan",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2349,6 +2365,7 @@ dependencies = [
  "insta",
  "libc",
  "loom",
+ "makefile-lossless",
  "mockall",
  "nix",
  "once_cell",
@@ -2969,6 +2986,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
 name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,6 +3130,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3785,6 +3820,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
+
+[[package]]
 name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4267,7 +4308,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,6 +245,7 @@ error_impl_error = "deny"
 result_large_err = "deny"
 
 [dev-dependencies]
+makefile-lossless = "0.3.40"
 temp-env = "0.3"
 color-eyre = "0.6"
 diesel = { version = "2", default-features = false, features = ["postgres"] }

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,9 @@ MANIFEST_VERSION := $(strip $(shell awk '\
 	}' Cargo.toml))
 VERSION ?= $(MANIFEST_VERSION)
 ifeq ($(strip $(VERSION)),)
-$(error VERSION is empty; set [package].version in Cargo.toml or pass VERSION explicitly)
+# Immediate assignment keeps the read-time fatal error while remaining a
+# plain variable statement that static Makefile parsers can represent.
+VERSION_GUARD := $(error VERSION is empty; set [package].version in Cargo.toml or pass VERSION explicitly)
 endif
 CLIPPY_FLAGS ?= --all-targets --all-features -- -D warnings
 RUSTDOC_FLAGS ?= --cfg docsrs -D warnings

--- a/tests/makefile_version_guard.rs
+++ b/tests/makefile_version_guard.rs
@@ -1,0 +1,41 @@
+//! Regression coverage for the Makefile's package-version guard.
+
+use std::{path::Path, process::Command};
+
+use makefile_lossless::Makefile;
+
+const MAKEFILE: &str = include_str!("../Makefile");
+const VERSION_ERROR: &str =
+    "VERSION is empty; set [package].version in Cargo.toml or pass VERSION explicitly";
+
+fn repository_root() -> &'static Path { Path::new(env!("CARGO_MANIFEST_DIR")) }
+
+#[test]
+fn makefile_parses_without_recovery() {
+    let parse = Makefile::parse(MAKEFILE);
+
+    assert!(
+        parse.ok(),
+        "Makefile required parser recovery: {:?}",
+        parse.positioned_errors(),
+    );
+}
+
+#[test]
+fn empty_version_still_fails_during_makefile_read() {
+    let output = Command::new("make")
+        .args(["--no-print-directory", "--dry-run", "VERSION=", "lint"])
+        .current_dir(repository_root())
+        .output()
+        .unwrap_or_else(|error| panic!("failed to invoke make: {error}"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "empty VERSION unexpectedly succeeded"
+    );
+    assert!(
+        stderr.contains(VERSION_ERROR),
+        "empty VERSION reported an unexpected error:\n{stderr}",
+    );
+}


### PR DESCRIPTION
## Summary

This branch replaces the bare `$(error ...)` directive guarding an
empty `VERSION` with an immediate `VERSION_GUARD := $(error ...)`
assignment. GNU Make behaviour is identical — the assignment expands at
read time, so the same fatal error fires when the guarded branch is
taken — but the statement is now representable by static Makefile
parsers. Concordat's estate audit (Operation Parabellum) previously
reported this repository as `indeterminate` because `makeutil parse`
needed error recovery on the bare directive; the Makefile now parses
completely.

The review follow-up adds automated regression coverage using the same
`makefile-lossless` parser family and a black-box GNU Make invocation.

## Validation

- `makeutil parse Makefile`: status `complete` (was `recovered`)
- `make -n lint`: unchanged
- `VERSION= make -n lint`: still fails with
  `VERSION is empty; set [package].version in Cargo.toml or pass VERSION
  explicitly`
- `cargo test --test makefile_version_guard`: 2 passed
- `make check-fmt`: passed
- `make lint`: passed
- `make typecheck`: passed
- `make test`: 448 all-feature and 317 `dev-worker` tests passed
- `concordat artefact rule run rust-makefile-baseline`: the
  recovered-parse indeterminate finding is gone; only the estate-wide
  `WHITAKER ?=` finding remains (deferred to the estate remediation
  wave)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:

- Replace the bare VERSION `$(error ...)` guard with an immediate
  `VERSION_GUARD` variable assignment so static Makefile parsers can
  fully parse the Makefile.

## References

- Lody session:
  https://lody.ai/leynos/sessions/cf14927c-3db2-40af-a6bd-591d3a90814d
